### PR TITLE
fix: Lessons now open with a single click

### DIFF
--- a/src/theme/Training/PackOverview/lesson-details.tsx
+++ b/src/theme/Training/PackOverview/lesson-details.tsx
@@ -10,13 +10,14 @@ interface ILessonDetailsProps {
 export default function LessonDetails(props: ILessonDetailsProps) {
   const [open, setOpen] = useState(false);
 
-  const toggleOpen = () => {
+  const toggleOpen = (event) => {
+    event.preventDefault();
     setOpen(!open);
   }
 
   return (
-    <details open={open} onClick={toggleOpen} className={"LessonDetails"} >
-      <summary className="LessonTitle" >
+    <details open={open} className={"LessonDetails"} >
+      <summary onClick={toggleOpen} className="LessonTitle" >
         {props.lesson.title}
       </summary>
       <div className="PagesContainer" >


### PR DESCRIPTION
I made a change so that now the click action is handled by the summary itself. I also included a bit of code to stop the summary's default behavior of toggling the details open and closed.

Expected Behaviour:
![image](https://github.com/RAPID-Platform-Projects/Rapid-Docs/assets/124578061/b62b58e4-538a-455c-817a-1e6c591902cb)

