### PR TITLE
Search Index only regards docs

### DIFF
--- a/generate-ai-indexs.ts
+++ b/generate-ai-indexs.ts
@@ -112,7 +112,7 @@ function generateIndexDocuments() {
     });
   }
 
-  traverseFileTree("./docs");
+  traverseFileTree("./docs/Rapid");
 
   function getFirstHashTag(strArr) {
     for (const a of strArr) {


### PR DESCRIPTION
Narrowed down the file tree the we parse to generate search indexs to only regard the /docs/Rapid subfolder
This is to avoid indexing the blog posts as they rarely added value to the search